### PR TITLE
Add click version options and update setup.py to include README.md info

### DIFF
--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -11,6 +11,17 @@ def get_version():
         )
     ) as f:
         return f.readline().strip()
+    
+
+def get_description():
+    with open("README.md", "r") as fh:
+        long_description = fh.read()
+    return long_description
+
+
+def get_data_files():
+    data_files = [(".", ["README.md"])]
+    return data_files
 
 
 CLASSIFIERS = [
@@ -32,10 +43,13 @@ setup(
     packages=find_packages(),
     python_requires="{{cookiecutter.min_python_version}}",
     description="{{cookiecutter.project_description}}",
+    long_description=get_description(),
+    long_description_content_type="text/markdown",
     url="{{cookiecutter.project_url}}",
     version=get_version(),
     author="{{cookiecutter.full_name}}",
     author_email="{{cookiecutter.email}}",
+    data_files=get_data_files(),
     py_modules=["{{cookiecutter.project_slug}}"],
     install_requires=[
         "nextflow{{cookiecutter.nextflow_version}}",

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__main__.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__main__.py
@@ -9,7 +9,7 @@ import os
 import click
 from .util import (
     nek_base,
-    print_version,
+    get_version,
     copy_config,
     OrderedCommands,
     run_nextflow,
@@ -65,8 +65,11 @@ def common_options(func):
 @click.group(
     cls=OrderedCommands, context_settings=dict(help_option_names=["-h", "--help"])
 )
+@click.version_option(get_version(), "-v", "--version", is_flag=True)
 def cli():
-    """For more options, run:
+    """{{cookiecutter.project_description}}
+    \b
+    For more options, run:
     {{cookiecutter.project_slug}} command --help"""
     pass
 
@@ -145,7 +148,6 @@ cli.add_command(citation)
 
 
 def main():
-    print_version()
     cli()
 
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/util.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/util.py
@@ -16,12 +16,10 @@ def nek_base(rel_path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), rel_path)
 
 
-def print_version():
+def get_version():
     with open(nek_base("{{cookiecutter.project_slug}}.VERSION"), "r") as f:
         version = f.readline()
-    click.echo(
-        "\n" + "{{cookiecutter.project_name}} version " + version + "\n", err=True
-    )
+    return version
 
 
 def print_citation():


### PR DESCRIPTION
This PR includes the following changes to support PyPI release.

* Use `click.version_option` to print out the tool version with `-v` option
* Add `description` in `cli()`
* Add files and README file as `data_files` in `setup.py`
* Add `long_description` from README file in `setup.py`